### PR TITLE
renamed scenario runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The main example for such a runner can be found in the VM, here: https://github.
 
 However, more such runners are conceivable.
 
-To implement such a runner, create an object that implements interface `ScenarioExecutor`.
+To implement such a runner, create an object that implements interface `ScenarioRunner`.
 
 ## Alternate implementation
 

--- a/controller/scenarioDir.go
+++ b/controller/scenarioDir.go
@@ -10,8 +10,8 @@ import (
 )
 
 // RunAllJSONScenariosInDirectory walks directory, parses and prepares all json scenarios,
-// then calls scenarioExecutor for each of them.
-func (r *ScenarioRunner) RunAllJSONScenariosInDirectory(
+// then calls ScenarioRunner for each of them.
+func (r *ScenarioController) RunAllJSONScenariosInDirectory(
 	generalTestPath string,
 	specificTestPath string,
 	allowedSuffix string,

--- a/controller/scenarioOne.go
+++ b/controller/scenarioOne.go
@@ -23,7 +23,7 @@ func DefaultRunScenarioOptions() *RunScenarioOptions {
 }
 
 // RunSingleJSONScenario parses and prepares test, then calls testCallback.
-func (r *ScenarioRunner) RunSingleJSONScenario(contextPath string, options *RunScenarioOptions) error {
+func (r *ScenarioController) RunSingleJSONScenario(contextPath string, options *RunScenarioOptions) error {
 	scenario, parseErr := ParseScenariosScenario(r.Parser, contextPath)
 
 	if parseErr != nil {
@@ -37,5 +37,5 @@ func (r *ScenarioRunner) RunSingleJSONScenario(contextPath string, options *RunS
 
 	applyScenarioOptions(scenario, options)
 
-	return r.Executor.ExecuteScenario(scenario, r.Parser.ExprInterpreter.FileResolver)
+	return r.Executor.RunScenario(scenario, r.Parser.ExprInterpreter.FileResolver)
 }

--- a/controller/scenarioRunner.go
+++ b/controller/scenarioRunner.go
@@ -6,27 +6,27 @@ import (
 	mj "github.com/multiversx/mx-chain-scenario-go/model"
 )
 
-// ScenarioExecutor describes a component that can run a VM scenario.
-type ScenarioExecutor interface {
+// ScenarioRunner describes a component that can run a VM scenario.
+type ScenarioRunner interface {
 	// Reset clears state/world.
 	Reset()
 
-	// ExecuteScenario executes the scenario and checks if it passed. Failure is signaled by returning an error.
+	// RunScenario executes the scenario and checks if it passed. Failure is signaled by returning an error.
 	// The FileResolver helps with resolving external steps.
 	// TODO: group into a "execution context" param.
-	ExecuteScenario(*mj.Scenario, fr.FileResolver) error
+	RunScenario(*mj.Scenario, fr.FileResolver) error
 }
 
-// ScenarioRunner is a component that can run json scenarios, using a provided executor.
-type ScenarioRunner struct {
-	Executor    ScenarioExecutor
+// ScenarioController is a component that can run json scenarios, using a provided executor.
+type ScenarioController struct {
+	Executor    ScenarioRunner
 	RunsNewTest bool
 	Parser      mjparse.Parser
 }
 
-// NewScenarioRunner creates new ScenarioRunner instance.
-func NewScenarioRunner(executor ScenarioExecutor, fileResolver fr.FileResolver) *ScenarioRunner {
-	return &ScenarioRunner{
+// NewScenarioController creates new ScenarioController instance.
+func NewScenarioController(executor ScenarioRunner, fileResolver fr.FileResolver) *ScenarioController {
+	return &ScenarioController{
 		Executor: executor,
 		Parser:   mjparse.NewParser(fileResolver),
 	}


### PR DESCRIPTION
The rename is meant to
- avoid confusion between the scenario runner and the VM executor
- align it with the Rust implementation