### PR TITLE
block timestamp in milliseconds

### DIFF
--- a/scenario/executor/stepSetState.go
+++ b/scenario/executor/stepSetState.go
@@ -191,17 +191,19 @@ func convertBlockInfo(testBlockInfo *scenmodel.BlockInfo, currentInfo *worldmock
 
 	if currentInfo == nil {
 		currentInfo = &worldmock.BlockInfo{
-			BlockTimestamp: 0,
-			BlockNonce:     0,
-			BlockRound:     0,
-			BlockEpoch:     0,
-			RandomSeed:     nil,
+			BlockTimestampMs: 0,
+			BlockNonce:       0,
+			BlockRound:       0,
+			BlockEpoch:       0,
+			RandomSeed:       nil,
 		}
 	}
 
-	if !testBlockInfo.BlockTimestamp.OriginalEmpty() {
-		currentInfo.BlockTimestamp = testBlockInfo.BlockTimestamp.Value
-
+	if !testBlockInfo.BlockTimestampMs.OriginalEmpty() {
+		currentInfo.BlockTimestampMs = testBlockInfo.BlockTimestampMs.Value
+	} else if !testBlockInfo.BlockTimestamp.OriginalEmpty() {
+		// backwards compatibility
+		currentInfo.BlockTimestampMs = testBlockInfo.BlockTimestamp.Value * 1000
 	}
 
 	if !testBlockInfo.BlockNonce.OriginalEmpty() {

--- a/scenario/json/integrationTests/example.scen.json
+++ b/scenario/json/integrationTests/example.scen.json
@@ -185,6 +185,7 @@
             },
             "currentBlockInfo": {
                 "blockTimestamp": "511",
+                "blockTimestampMs": "511000",
                 "blockNonce": "522",
                 "blockRound": "533",
                 "blockEpoch": "544"

--- a/scenario/json/parse/parseBlockInfo.go
+++ b/scenario/json/parse/parseBlockInfo.go
@@ -23,6 +23,11 @@ func (p *Parser) processBlockInfo(blockInfoRaw oj.OJsonObject) (*scenmodel.Block
 			if err != nil {
 				return nil, fmt.Errorf("error parsing blockTimestamp: %w", err)
 			}
+		case "blockTimestampMs":
+			blockInfo.BlockTimestampMs, err = p.processUint64(kvp.Value)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing blockTimestampMs: %w", err)
+			}
 		case "blockNonce":
 			blockInfo.BlockNonce, err = p.processUint64(kvp.Value)
 			if err != nil {

--- a/scenario/json/write/writeScenario.go
+++ b/scenario/json/write/writeScenario.go
@@ -167,6 +167,9 @@ func blockInfoToOJ(blockInfo *scenmodel.BlockInfo) oj.OJsonObject {
 	if len(blockInfo.BlockTimestamp.Original) > 0 {
 		blockInfoOJ.Put("blockTimestamp", uint64ToOJ(blockInfo.BlockTimestamp))
 	}
+	if len(blockInfo.BlockTimestampMs.Original) > 0 {
+		blockInfoOJ.Put("blockTimestampMs", uint64ToOJ(blockInfo.BlockTimestampMs))
+	}
 	if len(blockInfo.BlockNonce.Original) > 0 {
 		blockInfoOJ.Put("blockNonce", uint64ToOJ(blockInfo.BlockNonce))
 	}

--- a/scenario/model/structScenario.go
+++ b/scenario/model/structScenario.go
@@ -25,11 +25,12 @@ type NewAddressMock struct {
 
 // BlockInfo contains data for the block info hooks
 type BlockInfo struct {
-	BlockTimestamp  JSONUint64
-	BlockNonce      JSONUint64
-	BlockRound      JSONUint64
-	BlockEpoch      JSONUint64
-	BlockRandomSeed *JSONBytesFromTree
+	BlockTimestamp   JSONUint64
+	BlockTimestampMs JSONUint64
+	BlockNonce       JSONUint64
+	BlockRound       JSONUint64
+	BlockEpoch       JSONUint64
+	BlockRandomSeed  *JSONBytesFromTree
 }
 
 // TraceGasStatus defines the trace gas status

--- a/worldmock/worldBlockchainHook.go
+++ b/worldmock/worldBlockchainHook.go
@@ -25,6 +25,11 @@ func ConvertTimeStampSecToMs(timeStamp uint64) uint64 {
 
 }
 
+// ConvertTimeStampMsToSeconds converts a timestamp from milliseconds to seconds.
+func ConvertTimeStampMsToSeconds(timeStamp uint64) uint64 {
+	return timeStamp / 1000
+}
+
 // NewAddress provides the address for a new account.
 // It looks up the explicit new address mocks, if none found generates one using a fake but realistic algorithm.
 func (b *MockWorld) NewAddress(creatorAddress []byte, creatorNonce uint64, vmType []byte) ([]byte, error) {
@@ -111,7 +116,7 @@ func (b *MockWorld) LastTimeStamp() uint64 {
 	if b.PreviousBlockInfo == nil {
 		return 0
 	}
-	return b.PreviousBlockInfo.BlockTimestamp
+	return ConvertTimeStampMsToSeconds(b.PreviousBlockInfo.BlockTimestampMs)
 }
 
 // LastTimeStampMs returns the timeStamp in milliseconds from the last committed block
@@ -119,24 +124,7 @@ func (b *MockWorld) LastTimeStampMs() uint64 {
 	if b.PreviousBlockInfo == nil {
 		return 0
 	}
-	return ConvertTimeStampSecToMs(b.PreviousBlockInfo.BlockTimestamp)
-}
-
-// CurrentTimeStampMs returns the timestamp in milliseconds from the current block
-func (b *MockWorld) CurrentTimeStampMs() uint64 {
-	if b.CurrentBlockInfo == nil {
-		return 0
-	}
-	return ConvertTimeStampSecToMs(b.CurrentBlockInfo.BlockTimestamp)
-}
-
-// EpochStartBlockTimeStampMs returns the timestamp in milliseconds of the first block of the current epoch
-func (b *MockWorld) EpochStartBlockTimeStampMs() uint64 {
-	if b.CurrentBlockInfo == nil {
-		return 0
-	}
-
-	return ConvertTimeStampSecToMs(b.CurrentBlockInfo.BlockTimestamp)
+	return b.PreviousBlockInfo.BlockTimestampMs
 }
 
 // LastRandomSeed returns the random seed from the last committed block
@@ -187,7 +175,18 @@ func (b *MockWorld) EpochStartBlockTimeStamp() uint64 {
 		return 0
 	}
 
-	return b.CurrentBlockInfo.BlockTimestamp
+	// TODO: add epoch start block field in setState, instead of using current block
+	return ConvertTimeStampMsToSeconds(b.CurrentBlockInfo.BlockTimestampMs)
+}
+
+// EpochStartBlockTimeStampMs returns the timestamp in milliseconds of the first block of the current epoch
+func (b *MockWorld) EpochStartBlockTimeStampMs() uint64 {
+	if b.CurrentBlockInfo == nil {
+		return 0
+	}
+
+	// TODO: add epoch start block field in setState, instead of using current block
+	return b.CurrentBlockInfo.BlockTimestampMs
 }
 
 // EpochStartBlockNonce returns the nonce of the first block of the current epoch
@@ -213,7 +212,15 @@ func (b *MockWorld) CurrentTimeStamp() uint64 {
 	if b.CurrentBlockInfo == nil {
 		return 0
 	}
-	return b.CurrentBlockInfo.BlockTimestamp
+	return ConvertTimeStampMsToSeconds(b.CurrentBlockInfo.BlockTimestampMs)
+}
+
+// CurrentTimeStampMs returns the timestamp in milliseconds from the current block
+func (b *MockWorld) CurrentTimeStampMs() uint64 {
+	if b.CurrentBlockInfo == nil {
+		return 0
+	}
+	return b.CurrentBlockInfo.BlockTimestampMs
 }
 
 // CurrentRandomSeed returns the random seed from the current header

--- a/worldmock/worldDef.go
+++ b/worldmock/worldDef.go
@@ -19,11 +19,11 @@ type NewAddressMock struct {
 
 // BlockInfo contains metadata about a mocked block
 type BlockInfo struct {
-	BlockTimestamp uint64
-	BlockNonce     uint64
-	BlockRound     uint64
-	BlockEpoch     uint32
-	RandomSeed     *[48]byte
+	BlockTimestampMs uint64
+	BlockNonce       uint64
+	BlockRound       uint64
+	BlockEpoch       uint32
+	RandomSeed       *[48]byte
 }
 
 // GetRandomSeedSlice retrieves the configured random seed or a slice of zeros.


### PR DESCRIPTION
Adding the "blockTimestampMs" field, to allow specifying block times in Mandos at the correct precision.

The same field has already been implemented in the Rust implementation.